### PR TITLE
omit support-v4 dependency in library

### DIFF
--- a/DoubleViewPager/build.gradle
+++ b/DoubleViewPager/build.gradle
@@ -90,7 +90,7 @@ android {
 //}
 
 dependencies {
-    compile 'com.android.support:support-v4:22.+'
+    //compile 'com.android.support:support-v4:22.+'
     compile fileTree(include: '*.jar', dir: 'libs')
 }
 


### PR DESCRIPTION
Couldn't build project with this lib because of included support-v4 lib.
omit from library
